### PR TITLE
Cleans up .travis.yml, adds JS-based JSON Linter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,27 @@
 language: python
-python:
-  - "2.6"
-  - "2.7"
-# this cheats the fact that travis doesn't have multi-language support
-rvm:
-  - "2.0"
-install: "pip install -r pip-requirements.txt"
-# both of these cheat the fact that travis doesn't have multi-language support, but there aren't that many python libraries that lint csvs and jsons
-before_script:
-  - npm install jsonlint -g
-  - gem install csvlint
-script:
-  - python forage.py
-  - python forage.py -w csv
-  - python forage.py -w json
-  - jsonlint output-hydrometric.json
-  - csvlint output-hydrometric.csv
+matrix:
+  include:
+    - os: linux
+      language: python
+      python: "2.6"
+      install: "pip install -r pip-requirements.txt"
+      # both of these cheat the fact that travis doesn't have multi-language support, but there aren't that many python libraries that lint json properly
+      before_script:
+        - npm install jsonlint -g
+      script:
+        - python forage.py
+        - python forage.py -w csv
+        - python forage.py -w json
+        - jsonlint output-hydrometric.json
+    - os: linux
+      language: python
+      python: "2.7"
+      install: "pip install -r pip-requirements.txt"
+      # both of these cheat the fact that travis doesn't have multi-language support, but there aren't that many python libraries that lint json properly
+      before_script:
+        - npm install jsonlint -g
+      script:
+        - python forage.py
+        - python forage.py -w csv
+        - python forage.py -w json
+        - jsonlint output-hydrometric.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,13 @@ python:
   - "2.6"
   - "2.7"
 install: "pip install -r pip-requirements.txt"
+# both of these cheat the fact that travis doesn't have multi-language support, but there aren't that many python libraries that lint csvs and jsons
+before_script:
+  - npm install jsonlint -g
+  - gem install csvlint
 script:
   - python forage.py
   - python forage.py -w csv
   - python forage.py -w json
+  - jsonlint output-hydrometric.json
+  - csvlint output-hydrometric.csv

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "2.7"
 # this cheats the fact that travis doesn't have multi-language support
 rvm:
-  - "2.2"
+  - "2.0"
 install: "pip install -r pip-requirements.txt"
 # both of these cheat the fact that travis doesn't have multi-language support, but there aren't that many python libraries that lint csvs and jsons
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: python
 python:
   - "2.6"
   - "2.7"
+# this cheats the fact that travis doesn't have multi-language support
+rvm:
+  - "2.2"
 install: "pip install -r pip-requirements.txt"
 # both of these cheat the fact that travis doesn't have multi-language support, but there aren't that many python libraries that lint csvs and jsons
 before_script:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Forage
 [![Build Status](https://travis-ci.org/NorvalLabs/forage.svg?branch=master)](https://travis-ci.org/NorvalLabs/forage)
+
 A set of tools to pull information from the [Canadian Government's Weather API](http://dd.weather.gc.ca/), with support for the hydrometric data for now. Support for more data is coming soon!
 
 ## Settings


### PR DESCRIPTION
After some frustrating work with Travis, I've successfully implemented a npm-based JSON linter into the build system. Unfortunately, travis doesn't support multiple languages, so this workaround will be needed. In addition, travis now builds from a build matrix, which makes future multi-language tests easier (just need to create another matrix with a different language). Still, each build itself is limited to one language.